### PR TITLE
 Lifecycle hooks upgrade; Some unnecessary code cleaning

### DIFF
--- a/src/components/cwc-dropdown/cwc-dropdown.tsx
+++ b/src/components/cwc-dropdown/cwc-dropdown.tsx
@@ -1,4 +1,4 @@
-import { Component, Prop, Element, HostElement, State, Method, PropDidChange } from '@stencil/core';
+import { Component, Prop, Element, HostElement, State, Method, Watch } from '@stencil/core';
 import Popper from 'popper.js';
 
 @Component({
@@ -23,11 +23,11 @@ export class StencilComponent {
         this.popper.scheduleUpdate()
     }
 
-    @PropDidChange('dropdownPlacement')
+    @Watch('dropdownPlacement')
     placementDidChangeHandler(newValue) {
         this.popper.options.placement = newValue
     }
-    @PropDidChange('triggerOverflow')
+    @Watch('triggerOverflow')
     overflowDidChangeHandler(newValue) {
         this.popper.options.modifiers.offset.offset = newValue ?
             '-10%r, -110%' :

--- a/src/components/cwc-multiselect/cwc-multiselect.tsx
+++ b/src/components/cwc-multiselect/cwc-multiselect.tsx
@@ -121,7 +121,6 @@ export class CwcMultiselect {
         })
     }
 
-    //TODO: rename this
     private findInComplex(data, address) {
         let temporary = []
         temporary = data.map(value =>

--- a/src/components/cwc-multiselect/cwc-multiselect.tsx
+++ b/src/components/cwc-multiselect/cwc-multiselect.tsx
@@ -22,8 +22,10 @@ export class CwcMultiselect {
     @State() filterValue: string = '';
     @State() optionsShown: boolean = false;
     @State() focusIndex: number = 0
-    @State() labels: any[] = [];
     @State() justAddedLabel: boolean = false;
+
+    @State() labels: any[] = [];
+    @State() results: any[] = [];
 
     private filtered: any[] = []
 
@@ -34,19 +36,42 @@ export class CwcMultiselect {
         this.justAddedLabel = true
     }
 
+    addResult(result: any) {
+        if (typeof result == 'string') {
+            this.results = [...this.results, result]
+        } else {
+            this.results = [...this.results, result.data]
+        }
+    }
+
+    removeResult(index) {
+        this.results = this.results.filter((r, i) => i !== index)
+        this.multiselectOnSubmit.emit(this.results)
+    }
+
     clearLabels() {
         this.labels = []
     }
 
     removeLabel(label) {
-        pull(this.labels, label)
+        let index = this.labels.indexOf(label)
+        this.removeResult(index)
+        this.labels = this.labels.filter((l, i) => i !== index)
+
+
     }
 
     multiselectOnSubmitHandler(result) {
         this.addLabel(result)
         this.filterValue = ''
         this.clearTextNodes()
-        this.multiselectOnSubmit.emit(result)
+
+        typeof this.filtered[this.focusIndex - 1] == 'string' ?
+            this.addResult(this.filtered[this.focusIndex - 1]) :
+            this.addResult(this.filtered[this.focusIndex - 1].data)
+
+
+        this.multiselectOnSubmit.emit(this.results)
     }
 
     /**
@@ -108,7 +133,7 @@ export class CwcMultiselect {
         return this.filterStringArray(temporary)
     }
 
-    getValue(val: string | any): string {
+    getStringValue(val: string | any): string {
         if (typeof val == 'string') {
             return val
         } else {
@@ -127,7 +152,7 @@ export class CwcMultiselect {
         let input: HTMLInputElement = document.querySelector(`#${this.idValue} div.form-control`)
         input.value = value
 
-        let result = this.getValue(this.filtered[index])
+        let result = this.getStringValue(this.filtered[index])
         this.multiselectOnSubmitHandler(result)
 
         this.close()
@@ -169,7 +194,7 @@ export class CwcMultiselect {
 
                         return this.labels.map(label =>
 
-                            <span contenteditable={false} class="badge badge-secondary" > {this.getValue(label)}
+                            <span contenteditable={false} class="badge badge-secondary" > {this.getStringValue(label)}
                                 <span aria-hidden="true" onClick={(e) => this.removeLabel(label)}>&times;</span>
                             </span>
                         )

--- a/src/components/cwc-typeahead/cwc-typeahead.tsx
+++ b/src/components/cwc-typeahead/cwc-typeahead.tsx
@@ -96,7 +96,6 @@ export class CwcTypeahead {
 
 
         input.value = value
-        debugger
 
         this.typeaheadOnSubmitHandler(result)
         this.close()

--- a/src/components/scb-alert/scb-alert.tsx
+++ b/src/components/scb-alert/scb-alert.tsx
@@ -3,7 +3,7 @@ import {
   Element,
   HostElement,
   Prop,
-  PropWillChange,
+  Watch,
   State,
   Method,
 } from '@stencil/core';
@@ -40,10 +40,10 @@ export class ScbAlert {
     this.show = false;
     setTimeout(() => {
       this.onDismiss(this.el);
-    },         150); // TODO Replace with configurable value?
+    }, 150); // TODO Replace with configurable value?
   }
 
-  @PropWillChange('animatable')
+  @Watch('animatable')
   componentWillLoad() {
     this.setShowFadeState();
   }

--- a/src/components/scb-list/scb-list.tsx
+++ b/src/components/scb-list/scb-list.tsx
@@ -1,4 +1,4 @@
-import { Component, Prop, PropDidChange, State, Event, EventEmitter, Element, Method } from '@stencil/core';
+import { Component, Prop, State, Event, EventEmitter, Element, Method, Watch } from '@stencil/core';
 import { VirtualNode, ListDataItem } from './scb-list-interfaces';
 
 // TODO: Move interpolation mechanics to lodash templates
@@ -62,12 +62,13 @@ export class StencilComponent {
             this.loadMore()
     }
 
-
-    @PropDidChange('items')
+    @Watch('items')
     itemsdidChangeHandler() {
         this.itemsData.length = 0
         this.initItemsData()
     }
+
+
 
     private initItemsData() {
 
@@ -175,19 +176,5 @@ export class StencilComponent {
                 {list}
             </div>
         );
-    }
-
-    /**
-     * Utils for performance check
-     */
-    private timeStart: any
-
-    private startPerfMark() {
-        this.timeStart = performance.now()
-    }
-
-    private endPerfMark() {
-        let timeEnd = performance.now()
-        console.log('Operations took ' + (timeEnd - this.timeStart) + 'ms.')
     }
 }

--- a/src/pages/multiselect-page/multiselect-page.tsx
+++ b/src/pages/multiselect-page/multiselect-page.tsx
@@ -34,8 +34,9 @@ export class MultiselectPage {
 
     @State() result
 
-    @Listen('typeaheadOnSubmit')
+    @Listen('multiselectOnSubmit')
     typeaheadOnSubmit(e) {
+        console.log('got results: ', e.detail)
         this.result = e.detail
     }
     searchString = 'data.name'


### PR DESCRIPTION
According to [CHANGELOG.md](https://github.com/ionic-team/stencil/blob/master/CHANGELOG.md#breaking-changes) and compile warnings of deprecation 'PropWillChange' and 'PropDidChange' decorators.
Updated @PropDidChange() hook in list, multiselect typeahead and alert components. Removed performance check methods in list component. Some 'debugger' statements.
f6b5366