### PR TITLE
fixed autocomplete issue while scrolling window at that time popper open

### DIFF
--- a/src/components/cwc-autocomplete-select/cwc-autocomplete-select.tsx
+++ b/src/components/cwc-autocomplete-select/cwc-autocomplete-select.tsx
@@ -369,4 +369,12 @@ export class CwcAutocompleteSelect {
         caretEl.innerHTML = '&nbsp;';
         input.appendChild(caretEl);
     }
+
+    @Listen('focusout')
+    clearResultOnFocusout() {
+        setTimeout(() => {
+            this.close()
+        }, 100)
+    }
+
 }


### PR DESCRIPTION
Fixed the auto complete issue while scrolling at that time popper was appeared there due to filter result not clear when close the popper.